### PR TITLE
Fix utf8 bug when you use toLowerCase method on none english pc.

### DIFF
--- a/HSCore-collections/src/main/java/me/hsgamer/hscore/map/CaseInsensitiveStringLinkedMap.java
+++ b/HSCore-collections/src/main/java/me/hsgamer/hscore/map/CaseInsensitiveStringLinkedMap.java
@@ -1,6 +1,7 @@
 package me.hsgamer.hscore.map;
 
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -19,33 +20,33 @@ public class CaseInsensitiveStringLinkedMap<V> extends LinkedHashMap<String, V> 
 
   @Override
   public V put(String key, V value) {
-    return super.put(key.toLowerCase(), value);
+    return super.put(key.toLowerCase(Locale.ENGLISH), value);
   }
 
   @Override
   public V get(Object key) {
-    return super.get(String.valueOf(key).toLowerCase());
+    return super.get(String.valueOf(key).toLowerCase(Locale.ENGLISH));
   }
 
   @Override
   public V getOrDefault(Object key, V def) {
-    return super.getOrDefault(String.valueOf(key).toLowerCase(), def);
+    return super.getOrDefault(String.valueOf(key).toLowerCase(Locale.ENGLISH), def);
   }
 
   @Override
   public boolean containsKey(Object key) {
-    return super.containsKey(String.valueOf(key).toLowerCase());
+    return super.containsKey(String.valueOf(key).toLowerCase(Locale.ENGLISH));
   }
 
   @Override
   public V remove(Object key) {
-    return super.remove(String.valueOf(key).toLowerCase());
+    return super.remove(String.valueOf(key).toLowerCase(Locale.ENGLISH));
   }
 
   @Override
   public void putAll(Map<? extends String, ? extends V> m) {
     Map<String, V> mp = new LinkedHashMap<>();
-    m.forEach((s, o) -> mp.put(s.toLowerCase(), o));
+    m.forEach((s, o) -> mp.put(s.toLowerCase(Locale.ENGLISH), o));
     super.putAll(mp);
   }
 }

--- a/HSCore-collections/src/main/java/me/hsgamer/hscore/map/CaseInsensitiveStringMap.java
+++ b/HSCore-collections/src/main/java/me/hsgamer/hscore/map/CaseInsensitiveStringMap.java
@@ -1,6 +1,7 @@
 package me.hsgamer.hscore.map;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -19,33 +20,33 @@ public class CaseInsensitiveStringMap<V> extends HashMap<String, V> {
 
   @Override
   public V put(String key, V value) {
-    return super.put(key.toLowerCase(), value);
+    return super.put(key.toLowerCase(Locale.ENGLISH), value);
   }
 
   @Override
   public V get(Object key) {
-    return super.get(String.valueOf(key).toLowerCase());
+    return super.get(String.valueOf(key).toLowerCase(Locale.ENGLISH));
   }
 
   @Override
   public V getOrDefault(Object key, V def) {
-    return super.getOrDefault(String.valueOf(key).toLowerCase(), def);
+    return super.getOrDefault(String.valueOf(key).toLowerCase(Locale.ENGLISH), def);
   }
 
   @Override
   public boolean containsKey(Object key) {
-    return super.containsKey(String.valueOf(key).toLowerCase());
+    return super.containsKey(String.valueOf(key).toLowerCase(Locale.ENGLISH));
   }
 
   @Override
   public V remove(Object key) {
-    return super.remove(String.valueOf(key).toLowerCase());
+    return super.remove(String.valueOf(key).toLowerCase(Locale.ENGLISH));
   }
 
   @Override
   public void putAll(Map<? extends String, ? extends V> m) {
     Map<String, V> mp = new HashMap<>();
-    m.forEach((s, o) -> mp.put(s.toLowerCase(), o));
+    m.forEach((s, o) -> mp.put(s.toLowerCase(Locale.ENGLISH), o));
     super.putAll(mp);
   }
 }


### PR DESCRIPTION
- Every time use toLowerCase() instead toLowerCase(Locale.ENGLISH) method for no-english computers.